### PR TITLE
Fix variable shadowing of built-in name 'type'

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -90,13 +90,13 @@ print("Service running..")
 
 while True:
     message = socket.recv_json()
-    type = message.get("type")
+    request_type = message.get("type")
 
-    if type == "mood":
+    if request_type == "mood":
         mood = message.get("mood")
         print(f"Received request for mood: {mood}")
         playlist = get_by_mood(mood)
-    elif type == "song":
+    elif request_type == "song":
         song = message.get("song")
         artist = message.get("artist")
         print(f"Received request for song: {song} by {artist}")


### PR DESCRIPTION
This PR renames the variable
`type` to `request_type` in the main message-handling loop.

Using `type` as a variable name shadows the built-in Python function `type()`. 